### PR TITLE
Create NullableEnumEditorDescriptor 

### DIFF
--- a/EpiCommonUtils/EpiCommonUtils.csproj
+++ b/EpiCommonUtils/EpiCommonUtils.csproj
@@ -239,7 +239,10 @@
   <ItemGroup>
     <Compile Include="Infrastructure\DependencyInjection\StructureMapDependencyInjectionRegistrationModule.cs" />
     <Compile Include="Infrastructure\EditorDescriptors\EnumEditorDescriptor.cs" />
+    <Compile Include="Infrastructure\EditorDescriptors\EnumSelectionFactory.cs" />
     <Compile Include="Infrastructure\EditorDescriptors\EpiUnselectableAttribute.cs" />
+    <Compile Include="Infrastructure\EditorDescriptors\NullableEnumEditorDescriptor.cs" />
+    <Compile Include="Infrastructure\EditorDescriptors\NullableEnumSelectionFactory.cs" />
     <Compile Include="Infrastructure\EntryValueConverter.cs" />
     <Compile Include="Infrastructure\EnumExtensions.cs" />
     <Compile Include="Infrastructure\FeatureViewLocation\FeatureViewLocationRazorViewEngine.cs" />

--- a/EpiCommonUtils/Infrastructure/EditorDescriptors/EnumEditorDescriptor.cs
+++ b/EpiCommonUtils/Infrastructure/EditorDescriptors/EnumEditorDescriptor.cs
@@ -12,7 +12,7 @@ namespace Forte.EpiCommonUtils.Infrastructure.EditorDescriptors
     {
     }
 
-    public class NullableEditorDescriptor<TEnum> : EnumEditorDescriptor<TEnum, NullableEnumSelectionFactory<TEnum>> where TEnum : struct, IConvertible
+    public class NullableEnumEditorDescriptor<TEnum> : EnumEditorDescriptor<TEnum, NullableEnumSelectionFactory<TEnum>> where TEnum : struct, IConvertible
     {
     }
 

--- a/EpiCommonUtils/Infrastructure/EditorDescriptors/EnumEditorDescriptor.cs
+++ b/EpiCommonUtils/Infrastructure/EditorDescriptors/EnumEditorDescriptor.cs
@@ -12,6 +12,10 @@ namespace Forte.EpiCommonUtils.Infrastructure.EditorDescriptors
     {
     }
 
+    public class NullableEditorDescriptor<TEnum> : EnumEditorDescriptor<TEnum, NullableEnumSelectionFactory<TEnum>> where TEnum : struct, IConvertible
+    {
+    }
+
     public class EnumEditorDescriptor<TEnum, TSelectionFactory> : EditorDescriptor where TEnum : struct, IConvertible
     {
         public override void ModifyMetadata(

--- a/EpiCommonUtils/Infrastructure/EditorDescriptors/EnumEditorDescriptor.cs
+++ b/EpiCommonUtils/Infrastructure/EditorDescriptors/EnumEditorDescriptor.cs
@@ -1,18 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.ComponentModel.DataAnnotations;
-using System.Linq;
-using System.Reflection;
 using EPiServer.Shell.ObjectEditing;
 using EPiServer.Shell.ObjectEditing.EditorDescriptors;
 
 namespace Forte.EpiCommonUtils.Infrastructure.EditorDescriptors
 {
     public class EnumEditorDescriptor<TEnum> : EnumEditorDescriptor<TEnum, EnumSelectionFactory<TEnum>> where TEnum: struct, IConvertible
-    {
-    }
-
-    public class NullableEnumEditorDescriptor<TEnum> : EnumEditorDescriptor<TEnum, NullableEnumSelectionFactory<TEnum>> where TEnum : struct, IConvertible
     {
     }
 
@@ -28,67 +21,6 @@ namespace Forte.EpiCommonUtils.Infrastructure.EditorDescriptors
                 "epi-cms/contentediting/editors/SelectionEditor";
 
             base.ModifyMetadata(metadata, attributes);
-        }
-    }
-    
-    public class NullableEnumSelectionFactory<TEnum> : EnumSelectionFactory<TEnum> where TEnum : struct, IConvertible
-    {
-        public override IEnumerable<ISelectItem> GetSelections(ExtendedMetadata metadata)
-        {
-            return new[]{new SelectItem
-            {
-                Text = "",
-                Value = null,
-            }}.Concat(base.GetSelections(metadata));
-        }
-    }
-    
-    public class EnumSelectionFactory<TEnum> : ISelectionFactory where TEnum: struct, IConvertible
-    {
-        public virtual IEnumerable<ISelectItem> GetSelections(ExtendedMetadata metadata)
-        {
-            var values = Enum.GetValues(typeof(TEnum));
-            foreach (var value in values)
-            {
-                var enumType = typeof(TEnum);
-                var memberInfos = enumType.GetMember(value.ToString());
-                if (memberInfos[0].CustomAttributes.Any(x => x.AttributeType == typeof(EpiUnselectableAttribute)) == false)
-                {
-                    yield return new SelectItem
-                    {
-                        Text = GetEnumText((TEnum) value),
-                        Value = value
-                    };
-                }
-            }
-        }
-
-        private static string GetEnumText(TEnum value)
-        {
-            var localizedEnumText = value.GetLocalizedName();
-
-            if (string.IsNullOrEmpty(localizedEnumText) == false)
-            {
-                return localizedEnumText;
-            }
-
-            var displayAttributeText = GetDisplayFromAttribute(value);
-
-            if (string.IsNullOrEmpty(displayAttributeText) == false)
-            {
-                return displayAttributeText;
-            }
-
-            return Enum.GetName(typeof(TEnum), value);
-        }
-        
-        private static string GetDisplayFromAttribute(object value)
-        {
-            var type = value.GetType();
-            var memberInfos = type.GetMember(value.ToString());
-            var displayAttribute = memberInfos[0].GetCustomAttribute<DisplayAttribute>();
-
-            return displayAttribute?.Name;
         }
     }
 }

--- a/EpiCommonUtils/Infrastructure/EditorDescriptors/EnumEditorDescriptor.cs
+++ b/EpiCommonUtils/Infrastructure/EditorDescriptors/EnumEditorDescriptor.cs
@@ -1,46 +1,90 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
 using System.Linq;
+using System.Reflection;
 using EPiServer.Shell.ObjectEditing;
 using EPiServer.Shell.ObjectEditing.EditorDescriptors;
 
 namespace Forte.EpiCommonUtils.Infrastructure.EditorDescriptors
 {
-    public class EnumEditorDescriptor<TEnum> : EditorDescriptor where TEnum: struct, IConvertible
+    public class EnumEditorDescriptor<TEnum> : EnumEditorDescriptor<TEnum, EnumSelectionFactory<TEnum>> where TEnum: struct, IConvertible
+    {
+    }
+
+    public class EnumEditorDescriptor<TEnum, TSelectionFactory> : EditorDescriptor where TEnum : struct, IConvertible
     {
         public override void ModifyMetadata(
             ExtendedMetadata metadata, 
             IEnumerable<Attribute> attributes)
         {
-            SelectionFactoryType = typeof(EnumSelectionFactory);
+            SelectionFactoryType = typeof(TSelectionFactory);
 
             ClientEditingClass = 
                 "epi-cms/contentediting/editors/SelectionEditor";
 
             base.ModifyMetadata(metadata, attributes);
         }
-
-        public class EnumSelectionFactory : ISelectionFactory
+    }
+    
+    public class NullableEnumSelectionFactory<TEnum> : EnumSelectionFactory<TEnum> where TEnum : struct, IConvertible
+    {
+        public override IEnumerable<ISelectItem> GetSelections(ExtendedMetadata metadata)
         {
-            public IEnumerable<ISelectItem> GetSelections(
-                ExtendedMetadata metadata)
+            return new[]{new SelectItem
             {
-                var values = Enum.GetValues(typeof(TEnum));
-                foreach (var value in values)
+                Text = "",
+                Value = null,
+            }}.Concat(base.GetSelections(metadata));
+        }
+    }
+    
+    public class EnumSelectionFactory<TEnum> : ISelectionFactory where TEnum: struct, IConvertible
+    {
+        public virtual IEnumerable<ISelectItem> GetSelections(ExtendedMetadata metadata)
+        {
+            var values = Enum.GetValues(typeof(TEnum));
+            foreach (var value in values)
+            {
+                var enumType = typeof(TEnum);
+                var memberInfos = enumType.GetMember(value.ToString());
+                if (memberInfos[0].CustomAttributes.Any(x => x.AttributeType == typeof(EpiUnselectableAttribute)) == false)
                 {
-                    var enumType = typeof(TEnum);
-                    var memberInfos = enumType.GetMember(value.ToString());
-                    if (memberInfos[0].CustomAttributes.Any(x => x.AttributeType == typeof(EpiUnselectableAttribute)) ==
-                        false)
+                    yield return new SelectItem
                     {
-                        yield return new SelectItem
-                        {
-                            Text = ((TEnum) value).GetLocalizedName(),
-                            Value = value
-                        };
-                    }
+                        Text = GetEnumText((TEnum) value),
+                        Value = value
+                    };
                 }
             }
+        }
+
+        private static string GetEnumText(TEnum value)
+        {
+            var localizedEnumText = value.GetLocalizedName();
+
+            if (string.IsNullOrEmpty(localizedEnumText) == false)
+            {
+                return localizedEnumText;
+            }
+
+            var displayAttributeText = GetDisplayFromAttribute(value);
+
+            if (string.IsNullOrEmpty(displayAttributeText) == false)
+            {
+                return displayAttributeText;
+            }
+
+            return Enum.GetName(typeof(TEnum), value);
+        }
+        
+        private static string GetDisplayFromAttribute(object value)
+        {
+            var type = value.GetType();
+            var memberInfos = type.GetMember(value.ToString());
+            var displayAttribute = memberInfos[0].GetCustomAttribute<DisplayAttribute>();
+
+            return displayAttribute?.Name;
         }
     }
 }

--- a/EpiCommonUtils/Infrastructure/EditorDescriptors/EnumSelectionFactory.cs
+++ b/EpiCommonUtils/Infrastructure/EditorDescriptors/EnumSelectionFactory.cs
@@ -1,0 +1,58 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Reflection;
+using EPiServer.Shell.ObjectEditing;
+
+namespace Forte.EpiCommonUtils.Infrastructure.EditorDescriptors
+{
+    public class EnumSelectionFactory<TEnum> : ISelectionFactory where TEnum: struct, IConvertible
+    {
+        public virtual IEnumerable<ISelectItem> GetSelections(ExtendedMetadata metadata)
+        {
+            var values = Enum.GetValues(typeof(TEnum));
+            foreach (var value in values)
+            {
+                var enumType = typeof(TEnum);
+                var memberInfos = enumType.GetMember(value.ToString());
+                if (memberInfos[0].CustomAttributes.Any(x => x.AttributeType == typeof(EpiUnselectableAttribute)) == false)
+                {
+                    yield return new SelectItem
+                    {
+                        Text = GetEnumText((TEnum) value),
+                        Value = value
+                    };
+                }
+            }
+        }
+
+        private static string GetEnumText(TEnum value)
+        {
+            var localizedEnumText = value.GetLocalizedName();
+
+            if (string.IsNullOrEmpty(localizedEnumText) == false)
+            {
+                return localizedEnumText;
+            }
+
+            var displayAttributeText = GetDisplayFromAttribute(value);
+
+            if (string.IsNullOrEmpty(displayAttributeText) == false)
+            {
+                return displayAttributeText;
+            }
+
+            return Enum.GetName(typeof(TEnum), value);
+        }
+        
+        private static string GetDisplayFromAttribute(object value)
+        {
+            var type = value.GetType();
+            var memberInfos = type.GetMember(value.ToString());
+            var displayAttribute = memberInfos[0].GetCustomAttribute<DisplayAttribute>();
+
+            return displayAttribute?.Name;
+        }
+    }
+}

--- a/EpiCommonUtils/Infrastructure/EditorDescriptors/NullableEnumEditorDescriptor.cs
+++ b/EpiCommonUtils/Infrastructure/EditorDescriptors/NullableEnumEditorDescriptor.cs
@@ -1,0 +1,8 @@
+using System;
+
+namespace Forte.EpiCommonUtils.Infrastructure.EditorDescriptors
+{
+    public class NullableEnumEditorDescriptor<TEnum> : EnumEditorDescriptor<TEnum, NullableEnumSelectionFactory<TEnum>> where TEnum : struct, IConvertible
+    {
+    }
+}

--- a/EpiCommonUtils/Infrastructure/EditorDescriptors/NullableEnumSelectionFactory.cs
+++ b/EpiCommonUtils/Infrastructure/EditorDescriptors/NullableEnumSelectionFactory.cs
@@ -1,0 +1,19 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EPiServer.Shell.ObjectEditing;
+
+namespace Forte.EpiCommonUtils.Infrastructure.EditorDescriptors
+{
+    public class NullableEnumSelectionFactory<TEnum> : EnumSelectionFactory<TEnum> where TEnum : struct, IConvertible
+    {
+        public override IEnumerable<ISelectItem> GetSelections(ExtendedMetadata metadata)
+        {
+            return new[]{new SelectItem
+            {
+                Text = "",
+                Value = null,
+            }}.Concat(base.GetSelections(metadata));
+        }
+    }
+}

--- a/EpiCommonUtils/Infrastructure/EnumExtensions.cs
+++ b/EpiCommonUtils/Infrastructure/EnumExtensions.cs
@@ -20,7 +20,12 @@ namespace Forte.EpiCommonUtils.Infrastructure
             var staticName = Enum.GetName(typeof(TEnum), value);
             
             var localizationPath = $"/enum/{typeof(TEnum).Name}/{staticName}";
-            return localizationService.GetString(localizationPath, staticName);
+            if (localizationService.TryGetString(localizationPath, out var localizedString))
+            {
+                return localizedString;
+            }
+
+            return string.Empty;
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Allow to use enums in Episerver models, selectable by editors. Usage:
 
 ```cs
 public enum EnumType {
+    [Display(Name = "Custom text")] // set value displayed to editor manually (if you don't want to use translations)
     Value1 = 1,
     Value2 = 2,
     [EpiUnselectable] IgnoredValue = 3 // add explicit values to make it less fragile for refactoring
@@ -65,6 +66,9 @@ In order to translate enum values for editor, define following in language XML f
 </languages>
 ```
 
+#### NullableEnumEditorDescriptor
+
+This is variation of `EnumEditorDescriptor` with one difference: by using `NullableEnumEditorDescriptor` you will get extra "empty" choice in the dropdown which will set null value to your property
 
 ### HostingEnvironment
 


### PR DESCRIPTION
Currently when using property 

```
[EditorDescriptor(EditorDescriptorType = typeof(EnumEditorDescriptor<SomeEnum>))]
public virtual SomeEnum SomeProperty { get; set; }
```

there's no way to set null value to this property (basically not to choose an option).

This PR introduces new way of working with `EnumEditorDescriptor` so now you can add property like this:

```
[EditorDescriptor(EditorDescriptorType = typeof(NullableEnumEditorDescriptor<SomeEnum>))]
public virtual SomeEnum SomeProperty { get; set; }
```

which will result in "empty option" to be available to be chosen in dropdown in EditMode in EpiServer.
![image](https://user-images.githubusercontent.com/1555694/92908897-eff58100-f426-11ea-9653-e08e4b583f26.png)


Additionaly: there's a support for `[Display]` attribute which can be used to change label of enum value in the dropdown