### PR TITLE
Add restrictions for WebApi dependencies to allow using ContentDeliveryAPI

### DIFF
--- a/EpiCommonUtils/EpiCommonUtils.csproj
+++ b/EpiCommonUtils/EpiCommonUtils.csproj
@@ -158,9 +158,8 @@
     <Reference Include="System.Drawing" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Net.Http.Formatting, Version=5.2.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.6\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
     <Reference Include="System.Runtime.CompilerServices.Unsafe, Version=4.0.4.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\packages\System.Runtime.CompilerServices.Unsafe.4.5.0\lib\netstandard2.0\System.Runtime.CompilerServices.Unsafe.dll</HintPath>
@@ -206,13 +205,11 @@
       <HintPath>..\packages\Microsoft.AspNet.WebPages.3.2.7\lib\net45\System.Web.Helpers.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="System.Web.Http, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.7\lib\net45\System.Web.Http.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Web.Http, Version=5.2.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.Core.5.2.6\lib\net45\System.Web.Http.dll</HintPath>
     </Reference>
-    <Reference Include="System.Web.Http.WebHost, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
-      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.7\lib\net45\System.Web.Http.WebHost.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="System.Web.Http.WebHost, Version=5.2.6.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.WebApi.WebHost.5.2.6\lib\net45\System.Web.Http.WebHost.dll</HintPath>
     </Reference>
     <Reference Include="System.Web.Mvc, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35">
       <HintPath>..\packages\Microsoft.AspNet.Mvc.5.2.7\lib\net45\System.Web.Mvc.dll</HintPath>

--- a/EpiCommonUtils/packages.config
+++ b/EpiCommonUtils/packages.config
@@ -12,10 +12,10 @@
   <package id="JetBrains.Annotations" version="2018.3.0" targetFramework="net471" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net471" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net471" />
-  <package id="Microsoft.AspNet.WebApi" version="5.2.6" allowedVersions="[5.2,5.2.7)" targetFramework="net471" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.6" allowedVersions="[5.2,5.2.7)" targetFramework="net471" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.6" allowedVersions="[5.2,5.2.7)" targetFramework="net471" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.6" allowedVersions="[5.2,5.2.7)" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.6" allowedVersions="[5.2.6,6)" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.6" allowedVersions="[5.2.6,6)" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.6" allowedVersions="[5.2.6,6)" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.6" allowedVersions="[5.2.6,6)" targetFramework="net471" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net471" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net471" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net471" />

--- a/EpiCommonUtils/packages.config
+++ b/EpiCommonUtils/packages.config
@@ -12,10 +12,10 @@
   <package id="JetBrains.Annotations" version="2018.3.0" targetFramework="net471" />
   <package id="Microsoft.AspNet.Mvc" version="5.2.7" targetFramework="net471" />
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net471" />
-  <package id="Microsoft.AspNet.WebApi" version="5.2.7" targetFramework="net471" />
-  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net471" />
-  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.7" targetFramework="net471" />
-  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.7" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi" version="5.2.6" allowedVersions="[5.2,5.2.7)" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi.Client" version="5.2.6" allowedVersions="[5.2,5.2.7)" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi.Core" version="5.2.6" allowedVersions="[5.2,5.2.7)" targetFramework="net471" />
+  <package id="Microsoft.AspNet.WebApi.WebHost" version="5.2.6" allowedVersions="[5.2,5.2.7)" targetFramework="net471" />
   <package id="Microsoft.AspNet.WebPages" version="3.2.7" targetFramework="net471" />
   <package id="Microsoft.Tpl.Dataflow" version="4.5.24" targetFramework="net471" />
   <package id="Microsoft.Web.Infrastructure" version="1.0.0.0" targetFramework="net471" />


### PR DESCRIPTION
Content Delivery API requires following version of Microsoft.AspNet.WebApi.WebHost (≥ 5.2.3 && ≤ 5.2.6)
https://nuget.episerver.com/package/?id=EPiServer.ContentDeliveryApi.Cms

We need to downgrade Microsoft.AspNet.WebApi.WebHost in our solution