### PR TITLE
Introduced UseUnderlyingType attribute

### DIFF
--- a/EpiCommonUtils/EpiCommonUtils.csproj
+++ b/EpiCommonUtils/EpiCommonUtils.csproj
@@ -240,6 +240,7 @@
     <Compile Include="Infrastructure\EditorDescriptors\EpiUnselectableAttribute.cs" />
     <Compile Include="Infrastructure\EditorDescriptors\NullableEnumEditorDescriptor.cs" />
     <Compile Include="Infrastructure\EditorDescriptors\NullableEnumSelectionFactory.cs" />
+    <Compile Include="Infrastructure\EditorDescriptors\UseUnderlyingTypeAttribute.cs" />
     <Compile Include="Infrastructure\EntryValueConverter.cs" />
     <Compile Include="Infrastructure\EnumExtensions.cs" />
     <Compile Include="Infrastructure\FeatureViewLocation\FeatureViewLocationRazorViewEngine.cs" />

--- a/EpiCommonUtils/Infrastructure/EditorDescriptors/EnumSelectionFactory.cs
+++ b/EpiCommonUtils/Infrastructure/EditorDescriptors/EnumSelectionFactory.cs
@@ -12,6 +12,8 @@ namespace Forte.EpiCommonUtils.Infrastructure.EditorDescriptors
         public virtual IEnumerable<ISelectItem> GetSelections(ExtendedMetadata metadata)
         {
             var values = Enum.GetValues(typeof(TEnum));
+            var useUnderlyingType = metadata.Attributes.Any(attribute => attribute is UseUnderlyingTypeAttribute);
+
             foreach (var value in values)
             {
                 var enumType = typeof(TEnum);
@@ -21,10 +23,17 @@ namespace Forte.EpiCommonUtils.Infrastructure.EditorDescriptors
                     yield return new SelectItem
                     {
                         Text = GetEnumText((TEnum) value),
-                        Value = value
+                        Value = GetValue((TEnum) value, useUnderlyingType),
                     };
                 }
             }
+        }
+
+        private static object GetValue(TEnum enumValue, bool useUnderlyingType)
+        {
+            return useUnderlyingType
+                ? Convert.ChangeType(enumValue, Enum.GetUnderlyingType(typeof(TEnum)))
+                : enumValue;
         }
 
         private static string GetEnumText(TEnum value)

--- a/EpiCommonUtils/Infrastructure/EditorDescriptors/UseUnderlyingTypeAttribute.cs
+++ b/EpiCommonUtils/Infrastructure/EditorDescriptors/UseUnderlyingTypeAttribute.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Forte.EpiCommonUtils.Infrastructure.EditorDescriptors
+{
+    /// <summary>
+    /// Use it on enum property to force EnumSelectionFactory to send its value to Episerver UI using underlying type.
+    /// For example, it might be useful to bypass custom JsonConverter applied to the enum.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Property)]
+    public class UseUnderlyingTypeAttribute : Attribute
+    {
+    }
+}

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ In order to translate enum values for editor, define following in language XML f
 </languages>
 ```
 
+#### UseUnderlyingTypeAttribute
+
+This attribute can be used on enum properties which are using `EnumEditorDescriptor` or `EnumSelectionFactory` in order to change how `SelectItem` is sent to Episerver UI.
+
+By default, enum values are serialized to json using a configured converter. In some cases, this might be undesirable and by adding `UseUnderlyingType` one can override this behavior.
+
+```cs
+    [EditorDescriptor(EditorDescriptorType = typeof(EnumEditorDescriptor<EnumType>))]
+    [UseUnderlyingType]
+    public virtual EnumType SomeEnum { get; set; }
+```
+
 #### NullableEnumEditorDescriptor
 
 This is variation of `EnumEditorDescriptor` with one difference: by using `NullableEnumEditorDescriptor` you will get extra "empty" choice in the dropdown which will set null value to your property


### PR DESCRIPTION
This new attribute can be used on enum properties which are using EnumSelectionFactory in order to change how SelectItem is sent to Episerver UI.

By default, enum values are serialized to json using a configured converter. In some cases, this might be undesirable and by adding UseUnderlyingType we can override this behavior.

Theoretically, we could always send enum value using integers (even Episerver's EnumSelectionFactory does that), but to prevent introducing potential breaking change (in case someone uses custom json converters right now), I've decided to extend the current implementation by adding a new attribute.